### PR TITLE
Admin dashboard polish: taller description field + active-only guest total

### DIFF
--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -31,10 +31,12 @@
 {% endmacro %}
 
 {% block content %}
-  {% set ns = namespace(adults=0, kids=0) %}
-  {% for e in events %}{% set ns.adults = ns.adults + (e.total_adults or 0) %}{% set ns.kids = ns.kids + (e.total_kids or 0) %}{% endfor %}
   {% set active_events = events | selectattr('active') | list %}
   {% set inactive_events = events | rejectattr('active') | list %}
+  {# Top summary reflects only active events — inactive ones are folded away,
+     so their guests shouldn't inflate the visible total. #}
+  {% set ns = namespace(adults=0, kids=0) %}
+  {% for e in active_events %}{% set ns.adults = ns.adults + (e.total_adults or 0) %}{% set ns.kids = ns.kids + (e.total_kids or 0) %}{% endfor %}
   <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap">
     <h1>Events</h1>
     <div class="btn-row">
@@ -44,13 +46,12 @@
   </div>
 
   {% if events %}
-    <p class="muted" style="margin-top:-0.25rem">
-      {{ events|length }} event{{ '' if events|length == 1 else 's' }} ·
-      <strong style="color:var(--ink)">{{ ns.adults + ns.kids }} guests</strong> total
-      ({{ ns.adults }} adults, {{ ns.kids }} kids)
-    </p>
-
     {% if active_events %}
+      <p class="muted" style="margin-top:-0.25rem">
+        {{ active_events|length }} active event{{ '' if active_events|length == 1 else 's' }} ·
+        <strong style="color:var(--ink)">{{ ns.adults + ns.kids }} guests</strong> total
+        ({{ ns.adults }} adults, {{ ns.kids }} kids)
+      </p>
       {{ event_table(active_events) }}
     {% else %}
       <p class="muted">No active events right now.</p>

--- a/templates/admin/event.html
+++ b/templates/admin/event.html
@@ -48,7 +48,7 @@
     <label>Map address <span class="muted" style="font-weight:400">— optional; used by the Google Maps link</span>
       <input name="address" value="{{ event.address }}" placeholder="123 Main St, Anytown">
     </label>
-    <label>Description<textarea name="description">{{ event.description }}</textarea></label>
+    <label>Description<textarea name="description" rows="8">{{ event.description }}</textarea></label>
     <label class="check"><input type="checkbox" name="active" {{ 'checked' if event.active }}> Accepting RSVPs</label>
     <label class="check"><input type="checkbox" name="listed" {{ 'checked' if event.listed }}> Show on the public home page</label>
     <button type="submit" style="margin-top:0.5rem">Save Details</button>

--- a/templates/admin/new.html
+++ b/templates/admin/new.html
@@ -15,7 +15,7 @@
     <label>Map address <span class="muted" style="font-weight:400">— optional; what "View on Google Maps" searches for</span>
       <input name="address" placeholder="123 Main St, Anytown">
     </label>
-    <label>Description<textarea name="description"></textarea></label>
+    <label>Description<textarea name="description" rows="8"></textarea></label>
     <label class="check"><input type="checkbox" name="active" checked> Accepting RSVPs</label>
     <label class="check"><input type="checkbox" name="listed"> Show on the public home page</label>
     <button type="submit" class="btn-block" style="margin-top:0.5rem">Create Event</button>

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -349,6 +349,27 @@ def test_dashboard_with_only_inactive_events(client):
     assert b"Dormant Fair" in page
 
 
+def test_dashboard_top_total_counts_only_active_guests(client):
+    # Active event with 3 guests.
+    client.post("/admin/new", headers=auth(), data={
+        "title": "Active Bash", "datetime": "2099-06-01T12:00", "active": "on", "listed": "on"})
+    client.post("/active-bash/rsvp", data={"name": "A", "adults": "2", "kids": "1"})
+    # Another event collects 18 guests while active, then gets closed (inactive).
+    client.post("/admin/new", headers=auth(), data={
+        "title": "Now Closed", "datetime": "2099-07-01T12:00", "active": "on", "listed": "on"})
+    client.post("/now-closed/rsvp", data={"name": "B", "adults": "9", "kids": "9"})
+    client.post("/admin/now-closed/edit", headers={**auth(), "Origin": "http://localhost"},
+                data={"title": "Now Closed", "datetime": "2099-07-01T12:00", "listed": "on"})  # active off
+
+    page = client.get("/admin", headers=auth()).data
+    # Top summary reflects only the active event's 3 guests, not the closed 18.
+    assert b"1 active event" in page
+    assert b"3 guests" in page
+    assert b"21 guests" not in page      # 3 + 18 must NOT be summed
+    assert b"18 guests" not in page
+    assert b"1 inactive event" in page   # the closed event is folded away
+
+
 # --- Settings page + notification toggles ------------------------------------
 
 def test_settings_kv_roundtrip_and_stats(client):


### PR DESCRIPTION
Two small admin-UI fixes (both touch `templates/admin/`).

## 1. Roomier Description field
The event Description textarea fell back to the global `min-height` (~3 lines), cramping longer blurbs. Set `rows="8"` on both the new-event and edit-event forms — still vertically resizable, and the public RSVP "notes" box is untouched.

## 2. Top guest total counts only active events
The dashboard summary summed guests across *every* event, including the inactive ones tucked into the fold — so it showed e.g. "3 events · 111 guests" while only 21 were actually visible. Now the summary reflects just the active events ("1 active event · 21 guests total"), and it's hidden when nothing is active. Inactive-event guests live only inside the fold.

Adds a test asserting a closed event's guests aren't summed into the top total.

All 29 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)