### PR TITLE
Neutral, per-event customizable RSVP notes hint

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,10 @@ ALLOWED_EXTENSIONS = ("png", "jpg", "jpeg", "webp")
 # in an unexpected type.
 FORMAT_TO_EXT = {"JPEG": "jpg", "PNG": "png", "WEBP": "webp"}
 
+# Neutral default for the public RSVP "notes" box. Events can override it per-event
+# (e.g. a potluck might ask "Bringing a side dish?"); blank falls back to this.
+DEFAULT_NOTES_HINT = "Anything we should know? Let us know!"
+
 app.teardown_appcontext(db.close_db)
 
 
@@ -159,6 +163,7 @@ def event_view(event):
         "maps_url": maps_url(event),
         "gcal_url": gcal_url(event),
         "cover_url": cover_url(event),
+        "notes_hint": event["notes_hint"] or DEFAULT_NOTES_HINT,
     }
 
 
@@ -421,11 +426,12 @@ def admin_new():
             location=request.form.get("location", "").strip(),
             address=request.form.get("address", "").strip(),
             description=request.form.get("description", "").strip(),
+            notes_hint=request.form.get("notes_hint", "").strip(),
             active=request.form.get("active") == "on",
             listed=request.form.get("listed") == "on",
         )
         return redirect(url_for("admin_event", slug=slug))
-    return render_template("admin/new.html")
+    return render_template("admin/new.html", default_notes_hint=DEFAULT_NOTES_HINT)
 
 
 @app.route("/admin/<slug>")
@@ -440,6 +446,7 @@ def admin_event(slug):
         rsvps=db.list_rsvps(event["id"]),
         counts=db.guest_counts(event["id"]),
         cover_url=cover_url(event),
+        default_notes_hint=DEFAULT_NOTES_HINT,
     )
 
 
@@ -456,6 +463,7 @@ def admin_edit_event(slug):
         location=request.form.get("location", "").strip(),
         address=request.form.get("address", "").strip(),
         description=request.form.get("description", "").strip(),
+        notes_hint=request.form.get("notes_hint", "").strip(),
         active=request.form.get("active") == "on",
         listed=request.form.get("listed") == "on",
     )

--- a/db.py
+++ b/db.py
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS events (
     location    TEXT    NOT NULL DEFAULT '',
     address     TEXT    NOT NULL DEFAULT '',
     description TEXT    NOT NULL DEFAULT '',
+    notes_hint  TEXT    NOT NULL DEFAULT '',
     cover       TEXT,
     active      INTEGER NOT NULL DEFAULT 1,
     listed      INTEGER NOT NULL DEFAULT 0,
@@ -80,6 +81,8 @@ def init_db():
         cols = [r[1] for r in conn.execute("PRAGMA table_info(events)")]
         if "address" not in cols:
             conn.execute("ALTER TABLE events ADD COLUMN address TEXT NOT NULL DEFAULT ''")
+        if "notes_hint" not in cols:
+            conn.execute("ALTER TABLE events ADD COLUMN notes_hint TEXT NOT NULL DEFAULT ''")
         rcols = [r[1] for r in conn.execute("PRAGMA table_info(rsvps)")]
         if "token" not in rcols:
             conn.execute("ALTER TABLE rsvps ADD COLUMN token TEXT")
@@ -119,27 +122,29 @@ def slug_exists(slug):
     return get_event(slug) is not None
 
 
-def create_event(slug, title, dt, location, description, active=True, listed=False, address=""):
+def create_event(slug, title, dt, location, description, active=True, listed=False,
+                 address="", notes_hint=""):
     db = get_db()
     db.execute(
         """INSERT INTO events (slug, title, datetime, location, address, description,
-                               active, listed, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                               notes_hint, active, listed, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (slug, title, dt, location, address, description,
-         int(active), int(listed), _now()),
+         notes_hint, int(active), int(listed), _now()),
     )
     db.commit()
     return get_event(slug)
 
 
-def update_event(slug, title, dt, location, description, active, listed, address=""):
+def update_event(slug, title, dt, location, description, active, listed,
+                 address="", notes_hint=""):
     db = get_db()
     db.execute(
         """UPDATE events
            SET title = ?, datetime = ?, location = ?, address = ?, description = ?,
-               active = ?, listed = ?
+               notes_hint = ?, active = ?, listed = ?
            WHERE slug = ?""",
-        (title, dt, location, address, description, int(active), int(listed), slug),
+        (title, dt, location, address, description, notes_hint, int(active), int(listed), slug),
     )
     db.commit()
 

--- a/templates/admin/event.html
+++ b/templates/admin/event.html
@@ -49,6 +49,9 @@
       <input name="address" value="{{ event.address }}" placeholder="123 Main St, Anytown">
     </label>
     <label>Description<textarea name="description" rows="8">{{ event.description }}</textarea></label>
+    <label>RSVP notes prompt <span class="muted" style="font-weight:400">— grey hint in the guest's Notes box; leave blank for the default</span>
+      <input name="notes_hint" value="{{ event.notes_hint }}" placeholder="{{ default_notes_hint }}">
+    </label>
     <label class="check"><input type="checkbox" name="active" {{ 'checked' if event.active }}> Accepting RSVPs</label>
     <label class="check"><input type="checkbox" name="listed" {{ 'checked' if event.listed }}> Show on the public home page</label>
     <button type="submit" style="margin-top:0.5rem">Save Details</button>

--- a/templates/admin/new.html
+++ b/templates/admin/new.html
@@ -16,6 +16,9 @@
       <input name="address" placeholder="123 Main St, Anytown">
     </label>
     <label>Description<textarea name="description" rows="8"></textarea></label>
+    <label>RSVP notes prompt <span class="muted" style="font-weight:400">— grey hint in the guest's Notes box; leave blank for the default</span>
+      <input name="notes_hint" placeholder="{{ default_notes_hint }}">
+    </label>
     <label class="check"><input type="checkbox" name="active" checked> Accepting RSVPs</label>
     <label class="check"><input type="checkbox" name="listed"> Show on the public home page</label>
     <button type="submit" class="btn-block" style="margin-top:0.5rem">Create Event</button>

--- a/templates/event.html
+++ b/templates/event.html
@@ -87,7 +87,7 @@
 
         <div style="margin-bottom:1.25rem;">
           <div class="field-label">Notes &amp; Requests</div>
-          <textarea name="notes" placeholder="Bringing a side dish? Dietary needs? Let us know!">{{ my_rsvp.notes if my_rsvp else '' }}</textarea>
+          <textarea name="notes" placeholder="{{ notes_hint }}">{{ my_rsvp.notes if my_rsvp else '' }}</textarea>
         </div>
 
         <button type="submit" class="btn-block">

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -460,3 +460,31 @@ def test_test_notification_rejects_unknown_channel(client):
                     headers={**auth(), "Origin": "http://localhost"},
                     data={"channel": "carrier-pigeon"})
     assert r.status_code == 400
+
+
+# --- Customizable RSVP notes hint --------------------------------------------
+
+def test_notes_hint_default_and_custom(client):
+    import app as app_module
+    default = app_module.DEFAULT_NOTES_HINT.encode()
+
+    # No hint provided -> the public notes box shows the neutral default,
+    # not the old potluck-assuming copy.
+    client.post("/admin/new", headers=auth(), data={
+        "title": "Plain Meet", "datetime": "2099-09-01T12:00", "active": "on", "listed": "on"})
+    page = client.get("/plain-meet").data
+    assert default in page
+    assert b"Bringing a side dish" not in page
+
+    # Custom hint at creation -> shown verbatim as the placeholder.
+    client.post("/admin/new", headers=auth(), data={
+        "title": "Potluck", "datetime": "2099-09-02T12:00", "active": "on", "listed": "on",
+        "notes_hint": "Bringing a dish? Tell us what!"})
+    assert b'placeholder="Bringing a dish? Tell us what!"' in client.get("/potluck").data
+
+    # Editing updates the hint, and the admin form shows the saved value.
+    client.post("/admin/potluck/edit", headers={**auth(), "Origin": "http://localhost"}, data={
+        "title": "Potluck", "datetime": "2099-09-02T12:00", "active": "on", "listed": "on",
+        "notes_hint": "Allergies? Let us know."})
+    assert b"Allergies? Let us know." in client.get("/potluck").data
+    assert b'value="Allergies? Let us know."' in client.get("/admin/potluck", headers=auth()).data


### PR DESCRIPTION
## Problem
The public RSVP "Notes & Requests" box hard-coded **"Bringing a side dish? Dietary needs? Let us know!"** — which assumes a potluck. At a non-food event, guests read it as a prompt and started volunteering "we'll bring chips and dip," etc.

## Change
- **Neutral default**: "Anything we should know? Let us know!", defined once as `app.DEFAULT_NOTES_HINT`.
- **Per-event override**: a new optional `notes_hint` column lets each event set its own prompt (a potluck can still ask "Bringing a side dish?"). Edited on the new/edit event forms; blank falls back to the default.
- Column added via the same lightweight ALTER-on-startup migration used for `address`/`token`, so existing databases upgrade seamlessly.

## Tests
Adds `test_notes_hint_default_and_custom`: default shown when unset (and the old potluck copy is gone), a custom hint renders as the placeholder, and editing updates both the public box and the admin form. 29 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)