### PR TITLE
Collect optional guest email + broadcast updates to RSVPs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,10 @@ Three layers, all server-rendered:
 - **`notify.py`** — best-effort RSVP notifications (Discord webhook + SMTP email),
   stdlib only. `submit_rsvp` calls `notify_rsvp(...)`, which fires on a daemon thread
   and swallows all errors, so a slow/broken endpoint never blocks or breaks an RSVP.
-  Channels are off unless their env var is set.
+  Channels are off unless their env var is set. The same SMTP wiring also powers
+  `send_guest_broadcast(...)` — the *synchronous*, admin-facing path that emails all
+  guests who left an address (BCC) when an event changes; it returns an error string
+  instead of swallowing failures, so the admin sees what happened.
 
 **Storage of state** (all under `DATA_DIR`, persisted by the Docker volume):
 - `rsvp.db` — events and RSVPs.
@@ -70,7 +73,8 @@ Three layers, all server-rendered:
   `/cover/<slug>`.
 - Admin (`@basic_auth_required`): `/admin`, `/admin/settings` (+ `/admin/settings/test`),
   `/admin/new`, `/admin/<slug>` (manage), `/admin/<slug>/edit`, `/admin/<slug>/delete`,
-  `/admin/<slug>/rsvp/<id>` (edit/delete), `/admin/<slug>/upload`, `/admin/<slug>/export.csv`.
+  `/admin/<slug>/rsvp/<id>` (edit/delete), `/admin/<slug>/notify` (email all guests),
+  `/admin/<slug>/upload`, `/admin/<slug>/export.csv`.
 
 ## Conventions / gotchas
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ own URL (`/cigar-club`, `/summer-feast`, …).
 - 🎟️ **Multiple events**, each addressed by a slug
 - 🏠 Public home page lists your **highlighted** events; unlisted events stay
   private — reachable only by their link
-- ✉️ Collects RSVPs with names, adult/kid counts, and notes
+- ✉️ Collects RSVPs with names, adult/kid counts, notes, and an **optional** email
+- 📣 Reach every guest who left an email — a one-click BCC draft in your own mail
+  app, or a server-sent broadcast (when SMTP is configured) for reschedules & updates
 - 🧑‍💻 Admin dashboard to create/edit events, edit the guest list, and export CSV
 - 📸 Per-event cover image
 - 🔒 Admin protected by HTTP Basic Auth
@@ -83,6 +85,20 @@ endpoint never affects the guest. Stdlib only.
 To get a Discord webhook: **Server Settings → Integrations → Webhooks → New Webhook**,
 pick a channel, **Copy Webhook URL**. (Prefer phone push? ntfy.sh is a ~10-line add in
 `notify.py`.)
+
+### 📣 Reaching your guests (reschedules & updates)
+
+RSVPs collect an **optional** email — used for nothing but reaching that guest if
+plans change. Each event's manage page (`/admin/<slug>`) has a **Reach your guests**
+section with two ways to message everyone who left one:
+
+- **Email all guests** — opens a draft in *your own* mail app with every address in
+  BCC (hidden from each other). Works with zero configuration.
+- **Send from the server** — appears when `SMTP_HOST` is set; writes a subject +
+  message and the server sends it (guests BCC'd, replies routed to `NOTIFY_EMAIL`).
+
+So the same SMTP settings above power both admin notifications *and* outbound guest
+broadcasts. Guests who skip the email field simply aren't reachable this way.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -205,6 +205,21 @@ def maps_url(event):
     return "https://www.google.com/maps/search/?api=1&query=" + quote(query)
 
 
+def guest_mailto(event, emails):
+    """A ``mailto:`` link that drafts an email to every guest in BCC.
+
+    The zero-config way to reach guests: opens the admin's own mail client with
+    addresses hidden from each other (BCC) and the subject pre-filled. Returns
+    None when nobody has left an email yet.
+    """
+    if not emails:
+        return None
+    params = urlencode({"subject": f"Update: {event['title']}"}, quote_via=quote)
+    # BCC addresses go in raw (joined by commas) — mail clients expect them
+    # unencoded, and addresses never contain characters that need escaping.
+    return "mailto:?bcc=" + ",".join(emails) + "&" + params
+
+
 def cover_url(event):
     """Cover image URL with an mtime cache-buster so a re-upload shows at once."""
     if not event["cover"]:
@@ -276,6 +291,7 @@ def submit_rsvp(slug):
     adults = safe_int(request.form.get("adults", 1))
     kids = safe_int(request.form.get("kids", 0))
     notes = request.form.get("notes", "").strip()[:1000]
+    email = request.form.get("email", "").strip()[:254]
 
     # If this browser already holds a token for an RSVP to this event, update
     # that row instead of creating a duplicate. The token is an unguessable
@@ -284,10 +300,10 @@ def submit_rsvp(slug):
     updated = bool(existing and existing["event_id"] == event["id"])
     if updated:
         token = existing["token"]
-        db.update_rsvp(existing["id"], name[:200], adults, kids, notes)
+        db.update_rsvp(existing["id"], name[:200], adults, kids, notes, email)
     else:
         token = secrets.token_urlsafe(16)
-        db.add_rsvp(event["id"], name[:200], adults, kids, notes, token)
+        db.add_rsvp(event["id"], name[:200], adults, kids, notes, token, email)
 
     # Best-effort ping to any configured + enabled channel (Discord/email).
     # Compute the fresh total and the per-channel toggles here, in the request
@@ -440,6 +456,7 @@ def admin_event(slug):
     event = db.get_event(slug)
     if not event:
         abort(404)
+    emails = db.guest_emails(event["id"])
     return render_template(
         "admin/event.html",
         event=event,
@@ -447,6 +464,11 @@ def admin_event(slug):
         counts=db.guest_counts(event["id"]),
         cover_url=cover_url(event),
         default_notes_hint=DEFAULT_NOTES_HINT,
+        email_count=len(emails),
+        mailto_url=guest_mailto(event, emails),
+        smtp_configured=notify.smtp_configured(),
+        broadcast_sent=request.args.get("sent"),
+        broadcast_error=request.args.get("error"),
     )
 
 
@@ -498,8 +520,34 @@ def admin_edit_rsvp(slug, rsvp_id):
             safe_int(request.form.get("adults", 0)),
             safe_int(request.form.get("kids", 0)),
             request.form.get("notes", "").strip(),
+            request.form.get("email", "").strip()[:254],
         )
     return redirect(url_for("admin_event", slug=slug))
+
+
+@app.route("/admin/<slug>/notify", methods=["POST"])
+@basic_auth_required
+def admin_notify_guests(slug):
+    """Server-side email broadcast to everyone who left an address.
+
+    The configured-SMTP counterpart to the mailto link: the admin writes a
+    subject + message here and the server sends it (guests Bcc'd). Result is
+    surfaced back on the manage page via query params, mirroring the Settings
+    test-notification pattern.
+    """
+    check_csrf()
+    event = db.get_event(slug)
+    if not event:
+        abort(404)
+    subject = request.form.get("subject", "").strip()[:200] or f"Update: {event['title']}"
+    message = request.form.get("message", "").strip()[:5000]
+    if not message:
+        return redirect(url_for("admin_event", slug=slug,
+                                error="Write a message before sending."))
+    error = notify.send_guest_broadcast(subject, message, db.guest_emails(event["id"]))
+    if error:
+        return redirect(url_for("admin_event", slug=slug, error=error))
+    return redirect(url_for("admin_event", slug=slug, sent="1"))
 
 
 @app.route("/admin/<slug>/export.csv")
@@ -510,10 +558,11 @@ def export_csv(slug):
         abort(404)
     buf = io.StringIO()
     writer = csv.writer(buf)
-    writer.writerow(["Name", "Adults", "Kids", "Notes"])
+    writer.writerow(["Name", "Email", "Adults", "Kids", "Notes"])
     for r in db.list_rsvps(event["id"]):
         writer.writerow([
-            csv_safe(r["name"]), r["adults"], r["kids"], csv_safe(r["notes"]),
+            csv_safe(r["name"]), csv_safe(r["email"]),
+            r["adults"], r["kids"], csv_safe(r["notes"]),
         ])
     return Response(
         buf.getvalue(),

--- a/db.py
+++ b/db.py
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS rsvps (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     event_id   INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
     name       TEXT    NOT NULL,
+    email      TEXT    NOT NULL DEFAULT '',
     adults     INTEGER NOT NULL DEFAULT 0,
     kids       INTEGER NOT NULL DEFAULT 0,
     notes      TEXT    NOT NULL DEFAULT '',
@@ -86,6 +87,8 @@ def init_db():
         rcols = [r[1] for r in conn.execute("PRAGMA table_info(rsvps)")]
         if "token" not in rcols:
             conn.execute("ALTER TABLE rsvps ADD COLUMN token TEXT")
+        if "email" not in rcols:
+            conn.execute("ALTER TABLE rsvps ADD COLUMN email TEXT NOT NULL DEFAULT ''")
         conn.commit()
     finally:
         conn.close()
@@ -170,6 +173,28 @@ def list_rsvps(event_id):
     ).fetchall()
 
 
+def guest_emails(event_id):
+    """Distinct, non-empty guest emails for an event, in RSVP order.
+
+    The reachable subset of guests — used to message everyone when an event
+    changes (e.g. a reschedule). Guests who left the email blank are simply
+    absent here; there's no other way to reach them.
+    """
+    rows = get_db().execute(
+        """SELECT email FROM rsvps
+           WHERE event_id = ? AND email != ''
+           ORDER BY created_at ASC""",
+        (event_id,),
+    ).fetchall()
+    seen, out = set(), []
+    for r in rows:
+        e = r["email"]
+        if e.lower() not in seen:
+            seen.add(e.lower())
+            out.append(e)
+    return out
+
+
 def guest_counts(event_id):
     row = get_db().execute(
         """SELECT COALESCE(SUM(adults), 0) AS adults,
@@ -181,12 +206,12 @@ def guest_counts(event_id):
     return {"adults": adults, "kids": kids, "total": adults + kids}
 
 
-def add_rsvp(event_id, name, adults, kids, notes, token=None):
+def add_rsvp(event_id, name, adults, kids, notes, token=None, email=""):
     db = get_db()
     db.execute(
-        """INSERT INTO rsvps (event_id, name, adults, kids, notes, token, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
-        (event_id, name, adults, kids, notes, token, _now()),
+        """INSERT INTO rsvps (event_id, name, email, adults, kids, notes, token, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (event_id, name, email, adults, kids, notes, token, _now()),
     )
     db.commit()
 
@@ -199,11 +224,11 @@ def get_rsvp_by_token(token):
     ).fetchone()
 
 
-def update_rsvp(rsvp_id, name, adults, kids, notes):
+def update_rsvp(rsvp_id, name, adults, kids, notes, email=""):
     db = get_db()
     db.execute(
-        "UPDATE rsvps SET name = ?, adults = ?, kids = ?, notes = ? WHERE id = ?",
-        (name, adults, kids, notes, rsvp_id),
+        "UPDATE rsvps SET name = ?, email = ?, adults = ?, kids = ?, notes = ? WHERE id = ?",
+        (name, email, adults, kids, notes, rsvp_id),
     )
     db.commit()
 

--- a/notify.py
+++ b/notify.py
@@ -144,6 +144,16 @@ def _send_email(subject, body):
     msg["From"] = _env("SMTP_FROM") or _env("SMTP_USER") or "rsvp@localhost"
     msg["To"] = _env("NOTIFY_EMAIL")
     msg.set_content(body)
+    _smtp_send(msg)
+
+
+def _smtp_send(msg):
+    """Open an SMTP connection (STARTTLS + optional auth) and send ``msg``.
+
+    Shared by the admin notification email and the guest broadcast. ``msg`` may
+    carry a ``Bcc`` header; ``send_message`` routes those recipients in the
+    envelope and strips the header before transmission.
+    """
     port = int(_env("SMTP_PORT") or 587)
     with smtplib.SMTP(_env("SMTP_HOST"), port, timeout=15) as s:
         if _env("SMTP_STARTTLS", "1").lower() not in ("0", "false", "no"):
@@ -152,3 +162,37 @@ def _send_email(subject, body):
         if user and password:
             s.login(user, password)
         s.send_message(msg)
+
+
+def smtp_configured():
+    """True when the server can send email on its own (broadcast path)."""
+    return bool(_env("SMTP_HOST"))
+
+
+def send_guest_broadcast(subject, body, recipients):
+    """Send one message to many guests via Bcc. Returns None on success, else an
+    error string (surfaced to the admin on the manage page).
+
+    Guests are Bcc'd so addresses stay private from one another. The admin's
+    ``NOTIFY_EMAIL`` (or the From address) goes in To, so there's always a real
+    recipient and the admin keeps a copy. Replies route back to the admin.
+    """
+    if not smtp_configured():
+        return "Email sending isn't configured on the server (set SMTP_HOST)."
+    recipients = [r for r in dict.fromkeys(r.strip() for r in recipients) if r]
+    if not recipients:
+        return "No guests have left an email address yet."
+    sender = _env("SMTP_FROM") or _env("SMTP_USER") or "rsvp@localhost"
+    reply_to = _env("NOTIFY_EMAIL") or sender
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["To"] = reply_to
+    msg["Bcc"] = ", ".join(recipients)
+    msg["Reply-To"] = reply_to
+    msg.set_content(body)
+    try:
+        _smtp_send(msg)
+        return None
+    except Exception as e:
+        return str(e)

--- a/static/style.css
+++ b/static/style.css
@@ -216,8 +216,11 @@ a.event-card:hover { text-decoration: none; }
   color: var(--mustard); margin-top: 0.25rem; display: inline-block;
 }
 .invitation .desc {
-  font-size: 1.1rem; font-style: italic; color: rgba(58,48,39,0.9);
-  max-width: 32rem; margin: 1.5rem auto 0;
+  font-size: 1.1rem; color: rgba(58,48,39,0.9);
+  max-width: 34rem; margin: 1.5rem auto 0;
+  /* Honor the line breaks the admin typed, and read it left-aligned like a
+     pinned note rather than a centered banner. */
+  text-align: left; white-space: pre-line; line-height: 1.65;
 }
 
 /* ---- Forms ---- */
@@ -225,6 +228,14 @@ label { display: block; font-weight: 700; margin-bottom: 0.4rem; }
 .field-label {
   font-size: 0.72rem; font-weight: 800; text-transform: uppercase;
   letter-spacing: 0.06em; color: var(--ink-faint); margin-bottom: 0.5rem;
+}
+.optional-tag {
+  font-weight: 700; text-transform: none; letter-spacing: 0;
+  color: var(--ink-faint); opacity: 0.75;
+}
+.field-hint {
+  font-size: 0.82rem; font-style: normal; color: var(--ink-soft);
+  margin: 0.5rem 0 0; line-height: 1.45; text-align: left;
 }
 input, textarea {
   width: 100%; font: inherit; color: var(--ink);

--- a/templates/admin/event.html
+++ b/templates/admin/event.html
@@ -12,6 +12,41 @@
     &nbsp;·&nbsp; <a href="{{ url_for('export_csv', slug=event.slug) }}">Download CSV</a></p>
 
   <hr>
+  <h2>Reach your guests</h2>
+  {% if broadcast_sent %}
+    <div class="card" style="border-color:var(--leaf);margin-bottom:1.25rem">
+      <strong>Message sent.</strong> It's on its way to {{ email_count }} guest{{ '' if email_count == 1 else 's' }} (Bcc'd).
+    </div>
+  {% elif broadcast_error %}
+    <div class="card" style="border-color:var(--barn-red);margin-bottom:1.25rem">
+      <strong>Couldn't send:</strong> {{ broadcast_error }}
+    </div>
+  {% endif %}
+
+  {% if email_count %}
+    <p class="muted">{{ email_count }} guest{{ 's' if email_count != 1 }} {{ 'has' if email_count == 1 else 'have' }} left an email — your way to tell everyone if the plans change.</p>
+
+    {% if mailto_url %}
+      <p><a class="btn btn-secondary" href="{{ mailto_url }}">✉ Email all guests</a></p>
+      <p class="muted" style="font-size:0.85rem">Opens a draft in your own mail app with every address in Bcc, so guests can't see each other's emails.</p>
+    {% endif %}
+
+    {% if smtp_configured %}
+      <form class="card" method="post" action="{{ url_for('admin_notify_guests', slug=event.slug) }}"
+            onsubmit="return confirm('Send this email to {{ email_count }} guest(s) now?')">
+        <p class="muted" style="margin-top:0">…or send it straight from the server — no mail app needed:</p>
+        <label>Subject<input name="subject" value="Update: {{ event.title }}"></label>
+        <label>Message<textarea name="message" rows="6" placeholder="Heads up — we've had to move this. The new date is…" required></textarea></label>
+        <button type="submit">Send to {{ email_count }} guest{{ '' if email_count == 1 else 's' }}</button>
+      </form>
+    {% else %}
+      <p class="muted" style="font-size:0.85rem">Want the server to send these for you (no mail app)? Set <code>SMTP_HOST</code> — see the README.</p>
+    {% endif %}
+  {% else %}
+    <p class="muted">No guest has left an email yet. Email is optional on the RSVP form; as people add one, you'll be able to message them all from here.</p>
+  {% endif %}
+
+  <hr>
   <h2>RSVPs</h2>
   {% if rsvps %}
     <div class="stack">
@@ -19,12 +54,14 @@
         <form class="card" method="post" action="{{ url_for('admin_edit_rsvp', slug=event.slug, rsvp_id=r.id) }}">
           <div class="row">
             <label>Name<input name="name" value="{{ r.name }}"></label>
-            <label>Notes<input name="notes" value="{{ r.notes }}"></label>
+            <label>Email <span class="muted" style="font-weight:400">— optional</span>
+              <input type="email" name="email" value="{{ r.email }}"></label>
           </div>
           <div class="row">
             <label>Adults<input type="number" name="adults" value="{{ r.adults }}" min="0"></label>
             <label>Kids<input type="number" name="kids" value="{{ r.kids }}" min="0"></label>
           </div>
+          <label>Notes<input name="notes" value="{{ r.notes }}"></label>
           <div class="btn-row" style="justify-content:flex-end">
             <button type="submit">Save</button>
             <button type="submit" name="delete" value="1" class="btn-danger"

--- a/templates/event.html
+++ b/templates/event.html
@@ -71,6 +71,13 @@
                  value="{{ my_rsvp.name if my_rsvp else '' }}">
         </div>
 
+        <div style="margin-bottom:1.25rem;">
+          <div class="field-label">Email <span class="optional-tag">optional</span></div>
+          <input class="input-underline" type="email" name="email" placeholder="you@example.com" autocomplete="email"
+                 value="{{ my_rsvp.email if my_rsvp else '' }}">
+          <p class="field-hint">Only used to reach you if the plans change (date, time, or location). No newsletters, no sharing — leave it blank if you'd rather not.</p>
+        </div>
+
         {% set a_val = my_rsvp.adults if my_rsvp else 1 %}
         {% set k_val = my_rsvp.kids if my_rsvp else 0 %}
         <div class="counters">

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -61,19 +61,21 @@ def test_create_event_and_rsvp_flow(client):
     # It shows up on the public landing page (listed + active + future).
     assert b"Cigar Club" in client.get("/").data
 
-    # Submit an RSVP.
+    # Submit an RSVP (with an optional email this time).
     conf = client.post("/cigar-club/rsvp", data={
-        "name": "Jane", "adults": "2", "kids": "1", "notes": "On my way",
+        "name": "Jane", "email": "jane@example.com",
+        "adults": "2", "kids": "1", "notes": "On my way",
     })
     assert conf.status_code == 200
     assert b"You're on the list!" in conf.data
 
-    # Counts reflected in admin + CSV export.
+    # Counts reflected in admin + CSV export (Email is now a column).
     admin = client.get("/admin/cigar-club", headers=auth())
     assert b"3 total guests" in admin.data
     csv = client.get("/admin/cigar-club/export.csv", headers=auth())
     assert csv.status_code == 200
-    assert b"Jane,2,1,On my way" in csv.data
+    assert b"Name,Email,Adults,Kids,Notes" in csv.data
+    assert b"Jane,jane@example.com,2,1,On my way" in csv.data
 
 
 def test_unlisted_event_hidden_from_home_but_reachable(client):
@@ -488,3 +490,125 @@ def test_notes_hint_default_and_custom(client):
         "notes_hint": "Allergies? Let us know."})
     assert b"Allergies? Let us know." in client.get("/potluck").data
     assert b'value="Allergies? Let us know."' in client.get("/admin/potluck", headers=auth()).data
+
+
+# --- Guest email + reach-your-guests broadcast -------------------------------
+
+def _make_event_with_emails(client, slug="party"):
+    client.post("/admin/new", headers=auth(), data={
+        "title": slug.title(), "datetime": "2099-07-04T17:00", "active": "on", "listed": "on"})
+    client.post(f"/{slug}/rsvp", data={"name": "Ann", "email": "ann@example.com", "adults": "1"})
+    # A second browser/guest with no email — must stay reachable-less, not crash.
+    c2 = client.application.test_client()
+    c2.post(f"/{slug}/rsvp", data={"name": "Bo", "adults": "2"})
+    c3 = client.application.test_client()
+    c3.post(f"/{slug}/rsvp", data={"name": "Cy", "email": "cy@example.com", "adults": "1"})
+
+
+def test_email_is_optional_on_rsvp_form(client):
+    # The public form advertises email as optional and notification-only.
+    client.post("/admin/new", headers=auth(), data={
+        "title": "Optin", "datetime": "2099-07-04T12:00", "active": "on", "listed": "on"})
+    page = client.get("/optin").data
+    assert b'name="email"' in page
+    assert b"optional" in page
+    assert b"if the plans change" in page
+    # And an RSVP with no email at all still succeeds.
+    r = client.post("/optin/rsvp", data={"name": "NoEmail", "adults": "1"})
+    assert r.status_code == 200
+
+
+def test_guest_emails_collected_and_deduped(client):
+    import app as app_module
+    _make_event_with_emails(client, "party")
+    with app_module.app.app_context():
+        import db
+        ev = db.get_event("party")
+        # Same email twice (different casing) collapses to one entry.
+        db.add_rsvp(ev["id"], "Ann2", 1, 0, "", email="ANN@example.com")
+        emails = db.guest_emails(ev["id"])
+        assert emails == ["ann@example.com", "cy@example.com"]
+
+
+def test_manage_page_shows_mailto_for_guests(client):
+    _make_event_with_emails(client, "party")
+    page = client.get("/admin/party", headers=auth()).data
+    assert b"Reach your guests" in page
+    assert b"Email all guests" in page
+    # mailto link carries both addresses in Bcc, subject prefilled.
+    assert b"mailto:?bcc=ann@example.com,cy@example.com" in page
+    assert b"2 guests have left an email" in page
+
+
+def test_manage_page_no_emails_message(client):
+    client.post("/admin/new", headers=auth(), data={
+        "title": "Quiet", "datetime": "2099-07-04T12:00", "active": "on", "listed": "on"})
+    client.post("/quiet/rsvp", data={"name": "Solo", "adults": "1"})  # no email
+    page = client.get("/admin/quiet", headers=auth()).data
+    assert b"No guest has left an email yet" in page
+    assert b"mailto:" not in page
+
+
+def test_broadcast_route_without_smtp_redirects_with_error(client, monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    _make_event_with_emails(client, "party")
+    r = client.post("/admin/party/notify",
+                    headers={**auth(), "Origin": "http://localhost"},
+                    data={"subject": "Moved!", "message": "New date is the 11th."})
+    assert r.status_code == 302
+    assert "error=" in r.headers["Location"]
+
+
+def test_broadcast_route_sends_when_configured(client, monkeypatch):
+    import app as app_module
+    sent = {}
+    monkeypatch.setattr(app_module.notify, "send_guest_broadcast",
+                        lambda subj, body, recips: sent.update(
+                            subject=subj, body=body, recips=list(recips)) or None)
+    _make_event_with_emails(client, "party")
+    r = client.post("/admin/party/notify",
+                    headers={**auth(), "Origin": "http://localhost"},
+                    data={"subject": "Moved!", "message": "New date is the 11th."})
+    assert r.status_code == 302
+    assert "sent=1" in r.headers["Location"]
+    assert sent["subject"] == "Moved!"
+    assert sent["recips"] == ["ann@example.com", "cy@example.com"]
+    # Empty message is rejected before any send.
+    sent.clear()
+    r2 = client.post("/admin/party/notify",
+                     headers={**auth(), "Origin": "http://localhost"},
+                     data={"message": "   "})
+    assert "error=" in r2.headers["Location"]
+    assert not sent
+
+
+def test_send_guest_broadcast_builds_bcc(monkeypatch):
+    import notify
+    monkeypatch.setenv("SMTP_HOST", "mail.example")
+    monkeypatch.setenv("SMTP_FROM", "rsvp@example.com")
+    monkeypatch.setenv("NOTIFY_EMAIL", "host@example.com")
+    captured = {}
+
+    def fake_send(msg):
+        captured["from"], captured["to"] = msg["From"], msg["To"]
+        captured["bcc"], captured["subject"] = msg["Bcc"], msg["Subject"]
+        captured["reply_to"], captured["body"] = msg["Reply-To"], msg.get_content()
+
+    monkeypatch.setattr(notify, "_smtp_send", fake_send)
+    err = notify.send_guest_broadcast("Moved!", "See you the 11th.",
+                                      ["a@x.com", "b@y.com", "a@x.com"])
+    assert err is None
+    assert captured["from"] == "rsvp@example.com"
+    assert captured["to"] == "host@example.com"        # admin keeps a copy
+    assert captured["reply_to"] == "host@example.com"  # replies route to admin
+    assert captured["bcc"] == "a@x.com, b@y.com"       # deduped, guests hidden
+    assert "See you the 11th." in captured["body"]
+
+
+def test_send_guest_broadcast_guards(monkeypatch):
+    import notify
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    assert "SMTP_HOST" in notify.send_guest_broadcast("s", "b", ["a@x.com"])
+    monkeypatch.setenv("SMTP_HOST", "mail.example")
+    assert notify.send_guest_broadcast("s", "b", []) == \
+        "No guests have left an email address yet."


### PR DESCRIPTION
## Why

When plans change (e.g. rescheduling the 4th-of-July meetup), there was no way to reach guests — RSVPs collected a name and headcount but no contact info, and `notify.py` only ever pinged the admin. This adds the path back to guests so a reschedule is trivial.

## What

**Collect contact info (optional, notification-only)**
- New `email` column on `rsvps` (+ startup migration so existing DBs upgrade in place).
- Public RSVP form gains an **optional** email field. Copy is explicit that it's only used to reach the guest if plans change — no newsletters, no sharing; blank is fine.

**Reach your guests** (new section on each event's manage page)
- **Email all guests** — one-click `mailto:` BCC draft in the admin's own mail app. Zero config, addresses hidden from each other.
- **Send from the server** — appears when `SMTP_HOST` is set; server sends the message (guests BCC'd, replies routed to `NOTIFY_EMAIL`). Reuses existing SMTP wiring.
- Email is editable per-RSVP and added to the CSV export (`Email` column).

**Drive-by fix**
- Event description now preserves the line breaks the admin typed (`white-space: pre-line`) and is left-aligned instead of centered — reads like a pinned note, not a banner.

## Tests
- 8 new tests (optional-email flow, dedup, mailto rendering, no-emails state, broadcast success / SMTP-missing / empty-message guards, BCC construction). Existing CSV assertion updated for the new column. **38 passed.**

Backward-compatible and additive: guests who skip the email still work; the server-send path stays invisible until `SMTP_HOST` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)