### PR TITLE
Fit the flyer on one printed page, tabs included

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -419,15 +419,35 @@ details.inactive-fold table { margin-top: 0.5rem; }
 }
 .tearoff:first-child { border-left: none; }
 
+/* One page, guaranteed: fixed margins make the printable area predictable,
+   and the flyer gets a hard height that fits it (letter and A4 alike). The
+   tab strip never shrinks; the description is the flexible piece that gets
+   clipped if content is truly too long. With tabs on, the cover, QR, and
+   title print a notch smaller so everything shares the sheet. */
+@page { margin: 0.4in; }
 @media print {
   .site-header, .site-footer, .no-print { display: none !important; }
   body { background: #fff; }
   main.container { max-width: none; padding: 0; }
   .flyer {
     border: none; border-radius: 0; box-shadow: none;
-    margin: 0; min-height: 9.4in;
+    margin: 0; height: 10.1in; overflow: hidden;
+    padding: 1.25rem 1.5rem 0;
   }
-  .tearoffs { break-inside: avoid; }
+  .flyer-body {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    flex: 1; min-height: 0; padding-bottom: 1rem;
+  }
+  .flyer-body > * { flex-shrink: 0; }
+  .flyer-cover { width: 100%; max-height: 2.4in; margin-bottom: 1rem; }
+  .flyer-desc { flex-shrink: 1; min-height: 0; overflow: hidden; font-size: 0.98rem; margin: 1rem auto; }
+  .flyer-qr { width: 2.2in; }
+  .tearoffs { flex-shrink: 0; margin: 0 -1.5rem; }
+  .tearoff { height: 1.2in; padding: 0.4rem 0; }
+  .has-tabs .flyer-title { font-size: 2.2rem; }
+  .has-tabs .flyer-cover { max-height: 1.6in; margin-bottom: 0.75rem; }
+  .has-tabs .flyer-desc { margin: 0.75rem auto; }
+  .has-tabs .flyer-qr { width: 1.9in; }
 }
 
 /* Optional "Please RSVP by ___" deadline line. */

--- a/templates/admin/flyer.html
+++ b/templates/admin/flyer.html
@@ -47,7 +47,7 @@
       {% endfor %}
     </div>
   {% else %}
-    <div class="flyer">
+    <div class="flyer{{ ' has-tabs' if tabs }}">
       <div class="flyer-body">
         {% if cover_url and show_cover %}<img class="flyer-cover" src="{{ cover_url }}" alt="">{% endif %}
         <h1 class="flyer-title">{{ event.title }}</h1>


### PR DESCRIPTION
The full-page flyer with tear-off tabs could spill onto a second sheet (cover image + content + tab strip > one page), forcing manual print scaling.

Fix: pin the print layout to exactly one page —
- fixed `@page` margins so the printable area is predictable;
- a hard flyer height (10.1in) that fits both letter and A4;
- the tab strip never shrinks; the description is the flex item that gives way (clipped only in pathological cases);
- with tabs on, the title, cover, and QR print slightly smaller so everything shares the sheet.

Verified via headless-Chrome print-to-PDF: worst case (cover + tabs + deadline + contact) is now a single clean page; the no-tabs and handbill layouts unchanged/verified too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)